### PR TITLE
Fix queries without quotations

### DIFF
--- a/src/behaviors/ViewsWorkElementQueryBehavior.php
+++ b/src/behaviors/ViewsWorkElementQueryBehavior.php
@@ -86,11 +86,11 @@ class ViewsWorkElementQueryBehavior extends Behavior
         $subQuery = $this->owner->subQuery;
         $query->leftJoin(
             '{{%viewswork_viewrecording}} AS ' . $tblName,
-            'elements_sites.elementId=' . $tblName . '.elementId AND elements_sites.siteId=' . $tblName . '.siteId'
+            '[[elements_sites.elementId]]=[[' . $tblName . '.elementId]] AND [[elements_sites.siteId]]=[[' . $tblName . '.siteId]]'
         );
         $subQuery->leftJoin(
             '{{%viewswork_viewrecording}} AS ' . $tblName,
-            'elements_sites.elementId=' . $tblName . '.elementId AND elements_sites.siteId=' . $tblName . '.siteId'
+            '[[elements_sites.elementId]]=[[' . $tblName . '.elementId]] AND [[elements_sites.siteId]]=[[' . $tblName . '.siteId]]'
         );
 
 
@@ -112,7 +112,7 @@ class ViewsWorkElementQueryBehavior extends Behavior
             $useQuery->addOrderBy($orderBy);
             // limit min views
             if ($this->minViews > 0) {
-                $useQuery->andWhere($tblName . '.' . $popularSortField . '>=' . $this->minViews);
+                $useQuery->andWhere('[[' . $tblName . '.' . $popularSortField . ']] >=' . $this->minViews);
             }
             $otherQuery->orderBy = null;
         }

--- a/src/services/Facade.php
+++ b/src/services/Facade.php
@@ -55,7 +55,7 @@ class Facade
         $opts+=self::SORT_POPULAR_OPTS;
         $query->leftJoin(
             '{{%viewswork_viewrecording}} AS _vr2',
-            'elements_sites.elementId=_vr2.elementId AND elements_sites.siteId=_vr2.siteId'
+            '[[elements_sites.elementId]]=[[_vr2.elementId]] AND [[elements_sites.siteId]]=[[_vr2.siteId]]'
         );
         $sortFieldMap = [
             'total' => 'viewsTotal',
@@ -72,7 +72,7 @@ class Facade
         $query->addOrderBy($orderBy);
         $minViews = (int)$opts['min_views'];
         if ($minViews > 0) {
-            $query->andWhere('_vr2.' . $sortField . '>=' . (int)$opts['min_views']);
+            $query->andWhere('[[_vr2.' . $sortField . ']] >=' . (int)$opts['min_views']);
         }
         return $query;
     }
@@ -87,7 +87,7 @@ class Facade
     {
         $query->leftJoin(
             '{{%viewswork_viewrecording}} AS _vr2',
-            'elements_sites.elementId=_vr2.elementId AND elements_sites.siteId=_vr2.siteId'
+            '[[elements_sites.elementId]]=[[_vr2.elementId]] AND [[elements_sites.siteId]]=[[_vr2.siteId]]'
         );
         $query->andWhere(Db::parseDateParam('_vr2.dateUpdated', $after, '>='));
         $orderBy = $query->orderBy;

--- a/src/services/ViewsWorkService.php
+++ b/src/services/ViewsWorkService.php
@@ -53,8 +53,8 @@ class ViewsWorkService extends Component
     {
         $siteId = SiteIdHelper::determineSiteId($element, $site);
         $record = ViewRecording::find()
-            ->andWhere('elementId=:elementId')
-            ->andWhere('siteId=:siteId')
+            ->andWhere('[[elementId]]=:elementId')
+            ->andWhere('[[siteId]]=:siteId')
             ->addParams(['elementId' => (int)$element->id, 'siteId' => $siteId])
             ->one();
         if (!$record) {


### PR DESCRIPTION
# Summary

This fixes exceptions thrown when the DBMS is PostgreSQL.

**Test me.** With these changes, I can verify the primary plugin features are
working as expected. I have not performed extensive testing or deep exploration
of the plugin code.

A redacted exception example:

```
SQLSTATE[42703]: Undefined column: 7 ERROR:  column elements_sites.elementid does not exist
LINE 10: LEFT JOIN "viewswork_viewrecording" "___vr" ON elements_site...
                                                        ^
HINT:  Perhaps you meant to reference the column "elements_sites.elementId".
```

# Reference

> Yii DAO will automatically convert such constructs into the corresponding
> quoted column or table names using the DBMS specific syntax.

[Quoting Table and Column Names](https://www.yiiframework.com/doc/guide/2.0/en/db-dao#quoting-table-and-column-names)
