### PR TITLE
Prevent Undefined array key "signature"

### DIFF
--- a/src/services/RegistrationUrlService.php
+++ b/src/services/RegistrationUrlService.php
@@ -59,7 +59,7 @@ class RegistrationUrlService extends Component
 
     public function verifySignedParams(array $queryParams) : array
     {
-        $signature = $queryParams[self::SIGNATURE_FIELD];
+        $signature = $queryParams[self::SIGNATURE_FIELD] ?? '';
         $expectedSignature = sha1($this->getSigningKey() . $queryParams[self::SIGNED_PARAMS_FIELD]);
         if ($expectedSignature !== $signature) {
             throw new BadRequestHttpException('Invalid signature');


### PR DESCRIPTION
Hi,

Occasionally we have been seeing `yii\base\ErrorException` with
>Undefined array key "signature"

This is caused by some bots trying random URLs, often stripping parameters. Adding a  null coalescing operator would cause the proper exception to be thrown on line 65.