### PR TITLE
Allows pixel action URL to retrieve any element based on its element ID

### DIFF
--- a/src/controllers/RegisterViewController.php
+++ b/src/controllers/RegisterViewController.php
@@ -25,7 +25,7 @@ class RegisterViewController extends Controller
         // get params and check signature
         $params = ViewsWork::$plugin->registrationUrlService->verifySignedParams($request->getQueryParams());
 
-        $element = Craft::$app->elements->getElementById($params['id']);
+        $element = Craft::$app->elements->getElementById($params['id'], null, '*');
         $service = ViewsWork::$plugin->viewsWorkService;
         $success = $service->recordView($element, $params['sid'], (float)$params['f']);
 


### PR DESCRIPTION
Multi-sites setups currently do not support the pixel if the different sites are located on different paths (example: .com/be, .com/de)

Setting the siteId parameter to * would fix this.